### PR TITLE
Fix Twitch iframe parent domain to use current hostname

### DIFF
--- a/src/components/now/twitch-stream.tsx
+++ b/src/components/now/twitch-stream.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTwitchStream } from "@/hooks/use-twitch-stream";
 import { PanelCard } from "@/components/hud/panel-card";
 import { HudLabel } from "@/components/hud/hud-label";
@@ -22,6 +23,11 @@ function LiveView({
   viewerCount: number;
   startedAt: string;
 }) {
+  const [parentHost, setParentHost] = useState<string | null>(null);
+  useEffect(() => {
+    setParentHost(window.location.hostname);
+  }, []);
+
   return (
     <div className="relative overflow-hidden rounded-[var(--radius-md)]">
       {/* CRT corner accents */}
@@ -50,12 +56,14 @@ function LiveView({
 
       {/* Twitch iframe — hidden on mobile */}
       <div className="hidden aspect-video w-full bg-black md:block">
-        <iframe
-          src="https://player.twitch.tv/?channel=shushu010829&parent=shushu.tw&parent=localhost&autoplay=false"
-          className="h-full w-full"
-          allowFullScreen
-          title="Twitch stream"
-        />
+        {parentHost ? (
+          <iframe
+            src={`https://player.twitch.tv/?channel=shushu010829&parent=${parentHost}&autoplay=false`}
+            className="h-full w-full"
+            allowFullScreen
+            title="Twitch stream"
+          />
+        ) : null}
       </div>
 
       {/* Mobile: show CTA instead of iframe */}


### PR DESCRIPTION
## Summary
Updated the Twitch iframe embed to dynamically use the current page's hostname instead of hardcoded domain values. This ensures the iframe works correctly across different deployment environments.

## Changes
- Added `useEffect` hook to capture the current `window.location.hostname` on component mount
- Modified the iframe `src` URL to use the dynamically captured hostname via template literal instead of hardcoded `parent=shushu.tw&parent=localhost`
- Wrapped iframe rendering with a conditional check to only render after `parentHost` is set, preventing hydration mismatches

## Implementation Details
- Uses React's `useState` and `useEffect` hooks to safely access `window.location.hostname` (client-side only)
- The conditional rendering (`{parentHost ? <iframe /> : null}`) ensures the iframe doesn't render during server-side rendering, avoiding hydration issues
- This approach maintains compatibility with Next.js's "use client" directive and server-side rendering

https://claude.ai/code/session_01SZnZr9WW3bvazwiJXW26nr